### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,6 @@
 name: 'CodeQL'
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ryasmi/baseroo/security/code-scanning/2](https://github.com/ryasmi/baseroo/security/code-scanning/2)

The best way to resolve the issue is to add an explicit `permissions` block specifying the minimal access needed for the workflow. For the CodeQL analysis workflow, read access to `contents` is generally sufficient. The most appropriate and minimal fix is to add the following block:

```yaml
permissions:
  contents: read
```

This should be added at the top level (root) of the workflow (just under the `name` property and before `on:`), so it applies to all jobs in the workflow. Alternatively, adding it at the job level under `jobs.analyse` (before `runs-on`) is acceptable, but adding it at the root makes the intent clearer and ensures future jobs inherit the least-privilege policy unless an individual job needs specific elevation.

No package imports, definitions, or further code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
